### PR TITLE
Use a software decoder as last resort

### DIFF
--- a/libstreaming/src/main/java/net/majorkernelpanic/streaming/audio/AACStream.java
+++ b/libstreaming/src/main/java/net/majorkernelpanic/streaming/audio/AACStream.java
@@ -199,7 +199,12 @@ public class AACStream extends AudioStream {
 		((AACLATMPacketizer)mPacketizer).setSamplingRate(mQuality.samplingRate);
 
 		mAudioRecord = new AudioRecord(MediaRecorder.AudioSource.MIC, mQuality.samplingRate, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT, bufferSize);
-		mMediaCodec = MediaCodec.createEncoderByType("audio/mp4a-latm");
+		try {
+			mMediaCodec = MediaCodec.createEncoderByType("audio/mp4a-latm");
+		} catch (IOException e){
+			Log.d(TAG, "Unable to instantiate a decoder, trying Google one...");
+			mMediaCodec = MediaCodec.createByCodecName("OMX.google.aac.encoder");
+		}
 		MediaFormat format = new MediaFormat();
 		format.setString(MediaFormat.KEY_MIME, "audio/mp4a-latm");
 		format.setInteger(MediaFormat.KEY_BIT_RATE, mQuality.bitRate);


### PR DESCRIPTION
Your app works for me on one device, but on another one I had to force the use of a software decoder for the audio stream.
The error was:
`Unable to instantiate a decoder for type 'audio/mp4a-latm'`

Honestly, I don't know if my fix is correct. Android documentation says to use [MediaCodecList.findDecoderForFormat](https://developer.android.com/reference/android/media/MediaCodecList.html#findDecoderForFormat(android.media.MediaFormat)), but that is available since SDK 21.